### PR TITLE
Updating chrome installation instructions

### DIFF
--- a/src/b1_example.py
+++ b/src/b1_example.py
@@ -291,7 +291,7 @@ small {
 <ul>Alternatively, you can get the location bar behavior of Firefox in Safari 3 by using the <a href="http://purefiction.net/keywurl/">keywurl</a> extension.</ul>
 
 <h3>Installing on Google Chrome</h3>
-<ul>Choose <code>Options</code> from the wrench menu to the right of the location bar in Chrome, then under the section <code>Default Search</code>, click the <code>Manage</code> button.  Click the <code>Add</code> button and then fill in the fields name, keyword, and URL with <code>""" + name + """</code>, <code>b1</code>, and <code>""" + self._base_url() + """?</code>.  Hit <code>OK</code> and then select """ + name + """ from the list of search engines and hit the <code>Make Default</code> button to make """ + name + """ your default search engine.  Type <code>list</code> into your location bar to see a list of commands you can use.</ul>
+<ul>Choose <code>Options</code> from the wrench menu to the right of the location bar in Chrome, then under the section <code>Default Search</code>, click the <code>Manage</code> button.  Click the <code>Add</code> button and then fill in the fields name, keyword, and URL with <code>""" + name + """</code>, <code>b1</code>, and <code>""" + self._base_url() + """?%s</code>.  Hit <code>OK</code> and then select """ + name + """ from the list of search engines and hit the <code>Make Default</code> button to make """ + name + """ your default search engine.  Type <code>list</code> into your location bar to see a list of commands you can use.</ul>
 
 <h3>Installing on Internet Explorer</h3>
 <ul>There aren't any great solutions for installing """ + name + """ on IE, but two OK solutions are:</ul>


### PR DESCRIPTION
Chrome now requires the use of %s for the query in order to be set as a default
Before:
![image](https://user-images.githubusercontent.com/11202679/149680639-9786ea02-9d76-496f-9ea1-7f67045ace39.png)
After:
![image](https://user-images.githubusercontent.com/11202679/149680667-297480af-9775-4c7e-8268-f6b1b57eba05.png)
